### PR TITLE
Batch all metrics

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -15,6 +15,14 @@ steps:
   #     # true.
   #     add_language_pragma: true
 
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  - simple_align:
+      cases: true
+      top_level_patterns: true
+      records: true
+
   # Import cleanup
   - imports:
       # There are different ways we can align names and lists.
@@ -53,7 +61,7 @@ steps:
       #   > import qualified Data.List      as List
       #   >     (concat, foldl, foldr, head, init, last, length)
       #
-      # Default: after alias
+      # Default: after_alias
       list_align: after_alias
 
       # Long list align style takes effect when import is too long. This is
@@ -79,8 +87,26 @@ steps:
       # Default: inline
       long_list_align: inline
 
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
       # List padding determines indentation of import list on lines after import.
-      # This option affects 'list_align' and 'long_list_align'.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
       list_padding: 4
 
       # Separate lists option affects formating of import list for type
@@ -128,9 +154,6 @@ steps:
       # is set to true, it will remove those redundant pragmas. Default: true.
       remove_redundant: true
 
-  # Align the types in record declarations
-  - records: {}
-
   # Replace tabs by spaces. This is disabled by default.
   # - tabs:
   #     # Number of spaces to use for each tab. Default: 8, as specified by the
@@ -144,15 +167,23 @@ steps:
 # to. Different steps take this into account. Default: 80.
 columns: 80
 
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
 # Sometimes, language extensions are specified in a cabal file or from the
 # command line instead of using language pragmas in the file. stylish-haskell
 # needs to be aware of these, so it can parse the file correctly.
 #
 # No language extensions are enabled by default.
-language_extensions:
-  - RecordWildCards
-  - OverloadedStrings
-  - LambdaCase
-  - MultiParamTypeClasses
-  - BangPatterns
-  - FlexibleContexts
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,17 @@ matrix:
     compiler: ": #stack default"
     addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-3"
-    compiler: ": #stack 7.10.2"
-    addons: {apt: {packages: [ghc-7.10.2], sources: [hvr-ghc]}}
-
-  - env: BUILD=stack ARGS="--resolver lts-5"
+  - env: BUILD=stack ARGS="--resolver lts-6"
     compiler: ": #stack 7.10.3"
     addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-7"
+    compiler: ": #stack 8.0.1"
+    addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
+
+  - env: BUILD=stack ARGS="--resolver lts-9"
+    compiler: ": #stack 8.0.2"
+    addons: {apt: {packages: [ghc-8.0.2], sources: [hvr-ghc]}}
 
   # Nightly builds are allowed to fail
   - env: BUILD=stack ARGS="--resolver nightly"
@@ -63,10 +67,6 @@ matrix:
   # Build on OS X in addition to Linux
   - env: BUILD=stack ARGS=""
     compiler: ": #stack default osx"
-    os: osx
-
-  - env: BUILD=stack ARGS="--resolver lts-3"
-    compiler: ": #stack 7.10.2 osx"
     os: osx
 
   - env: BUILD=stack ARGS="--resolver lts-5"

--- a/package.yaml
+++ b/package.yaml
@@ -13,7 +13,11 @@ dependencies:
   - base >=4.7 && <5
   - ekg-core >= 0.1 && < 1.0
   - amazonka >= 1.0.0
+  - amazonka-core >= 1.0.0
   - amazonka-cloudwatch >= 1.0.0
+  - aeson
+  - semigroups
+  - bytestring
   - lens
   - resourcet
   - text

--- a/package.yaml
+++ b/package.yaml
@@ -12,12 +12,13 @@ github: sellerlabs/ekg-cloudwatch
 dependencies:
   - base >=4.7 && <5
   - ekg-core >= 0.1 && < 1.0
-  - amazonka
-  - amazonka-cloudwatch
+  - amazonka >= 1.0.0
+  - amazonka-cloudwatch >= 1.0.0
+  - lens
+  - resourcet
+  - text
   - time
   - unordered-containers
-  - text
-  - lens
 
 library:
   source-dirs: src

--- a/src/System/Remote/Monitoring/CloudWatch.hs
+++ b/src/System/Remote/Monitoring/CloudWatch.hs
@@ -20,9 +20,6 @@ module System.Remote.Monitoring.CloudWatch
 import           Control.Concurrent                   (ThreadId, forkFinally,
                                                        myThreadId, threadDelay)
 import           Control.Exception
-import Control.Monad.Trans.AWS (runAWST)
-import Control.Exception.Lens (trying)
-import Control.Monad.Trans.Resource (runResourceT)
 import           Control.Lens
 import           Control.Monad                        (forM_, guard, void)
 import qualified Data.HashMap.Strict                  as Map
@@ -176,7 +173,7 @@ flushSample CloudWatchEnv{..} = void
     sendMetric metrics = do
       -- TODO: This call is limited to 40KB in size. Any larger and it will
       -- whine.
-      e <- trying _Error . void . runResourceT . runAWST cweAwsEnv . send $
+      e <- trying _Error . void . runResourceT . runAWS cweAwsEnv . send $
         putMetricData cweNamespace & pmdMetricData .~ metrics
       case e of
         Left err -> cweOnError err

--- a/src/System/Remote/Monitoring/CloudWatch.hs
+++ b/src/System/Remote/Monitoring/CloudWatch.hs
@@ -179,12 +179,17 @@ data SplitAcc = SplitAcc
 splitAt40KB :: [MetricDatum] -> NonEmpty [MetricDatum]
 splitAt40KB = splitAccData . foldl' go (SplitAcc ([] :| []) 0)
   where
+    limit = 40000
+    fudge =  2000
+    safety = limit - fudge
     go (SplitAcc (acc :| accs) size) x
-      | size + weight >= 38000 =
+      | size + weight >= safety =
           SplitAcc ((x : acc) :| accs) (size + weight)
       | otherwise =
           SplitAcc ([x] :| (acc : accs)) 0
-      where weight = weighDatum x
+      where
+        weight = weighDatum x
+
 
 flushSample :: CloudWatchEnv -> Metrics.Sample -> IO ()
 flushSample CloudWatchEnv{..} = void

--- a/src/System/Remote/Monitoring/CloudWatch.hs
+++ b/src/System/Remote/Monitoring/CloudWatch.hs
@@ -150,16 +150,15 @@ diffSamples prev !curr = Map.foldlWithKey' combine Map.empty curr
     diffMetric _ _ = Nothing
 
 metricToDatum :: [Dimension] -> Text -> Metrics.Value -> Maybe MetricDatum
-metricToDatum dim name =
-  \case
-    Metrics.Counter n ->
-      Just $ mkDatum (mdValue ?~ fromIntegral n)
-    Metrics.Gauge n ->
-      Just $ mkDatum (mdValue ?~ fromIntegral n)
-    Metrics.Distribution d ->
-      fmap (\dist -> mkDatum (mdStatisticValues ?~ dist)) (conv d)
-    Metrics.Label l ->
-      Nothing
+metricToDatum dim name val = case val of
+  Metrics.Counter n ->
+    Just $ mkDatum (mdValue ?~ fromIntegral n)
+  Metrics.Gauge n ->
+    Just $ mkDatum (mdValue ?~ fromIntegral n)
+  Metrics.Distribution d ->
+    fmap (\dist -> mkDatum (mdStatisticValues ?~ dist)) (conv d)
+  Metrics.Label l ->
+    Nothing
   where
     mkDatum k =
       metricDatum name & mdDimensions .~ dim & k

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-6.15
+resolver: lts-9.15
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-9.15
+resolver: lts-9.8
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
The single metrics calls can be expensive. This PR batches all of the metrics into a single metric.

The API restricts the size of the request payload to 40KB. The current implementation does not care about that. I'll open an issue to measure and handle that appropriately.